### PR TITLE
T3: Realtime updates (SSE) for call sessions

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -1,37 +1,46 @@
 import express from "express";
 import cors from "cors";
 import { env } from "./config";
-import callsRouter from "./routes/calls.routes";
+import apiRouter from "./routes/index.routes";
 import { telnyxWebhook } from "./webhooks/telnyx.webhook";
 
 export function createApp() {
   const app = express();
 
-  // CORS + JSON por defecto
+  // CORS
   app.use(cors());
-  app.use(express.json());
 
-  // Webhook Telnyx: necesita raw body para verificar firma
+  // --- Webhook BEFORE express.json() ---
   app.post(
     `/webhooks/${env.WEBHOOK_SECRET_PATH}`,
+    // 1) keep raw bytes for signature verification
     express.raw({ type: "*/*" }),
-    // guardamos raw body en req.rawBody
-    (req: any, _res, next) => {
-      req.rawBody = Buffer.from(req.body);
-      next();
-    },
-    // parseamos JSON para tener req.body usable
-    (req: any, _res, next) => {
+    (req: any, res, next) => {
+      // ensure it's really a Buffer
+      if (!Buffer.isBuffer(req.body)) {
+        return res.status(415).send("raw body required");
+      }
+      const raw = req.body as Buffer;
+
+      // 2) expose raw for the verifier
+      req.rawBody = raw;
+
+      // 3) best-effort JSON parse to have req.body usable
       try {
-        req.body = JSON.parse(req.rawBody.toString("utf8"));
-      } catch {}
+        req.body = JSON.parse(raw.toString("utf8"));
+      } catch {
+        req.body = {};
+      }
       next();
     },
     telnyxWebhook
   );
 
-  // Rutas API
-  app.use("/api/calls", callsRouter);
+  // --- JSON parser for the rest of the API ---
+  app.use(express.json());
+
+  // API routes
+  app.use("/api", apiRouter);
 
   // Healthcheck
   app.get("/health", (_req, res) => res.json({ ok: true }));

--- a/apps/server/src/core/events.ts
+++ b/apps/server/src/core/events.ts
@@ -1,0 +1,26 @@
+import { EventEmitter } from "events";
+import type { Session } from "./state";
+
+const emitters = new Map<string, EventEmitter>();
+const counters = new Map<string, number>();
+
+export function getEmitter(sessionId: string) {
+  let em = emitters.get(sessionId);
+  if (!em) {
+    em = new EventEmitter();
+    emitters.set(sessionId, em);
+  }
+  return em;
+}
+
+function nextSeq(sessionId: string) {
+  const cur = counters.get(sessionId) ?? 0;
+  const next = cur + 1;
+  counters.set(sessionId, next);
+  return next;
+}
+
+export function publishSession(sessionId: string, session: Session) {
+  const em = getEmitter(sessionId);
+  em.emit("update", { seq: nextSeq(sessionId), session });
+}

--- a/apps/server/src/routes/calls.routes.ts
+++ b/apps/server/src/routes/calls.routes.ts
@@ -5,6 +5,7 @@ import { v4 as uuid } from "uuid";
 import { sessions } from "../core/state";
 import { dial } from "../services/telnyx.client";
 import { env } from "../config";
+import { publishSession } from "@core/events";
 
 const router = Router();
 
@@ -31,6 +32,7 @@ router.post("/bridge", async (req, res) => {
     b: { status: "dialing" },
     status: "a_dialing",
   });
+  publishSession(sessionId, sessions.get(sessionId)!);
 
   // client_state base64 para correlacionar los webhooks de A
   const clientStateA = Buffer.from(

--- a/apps/server/src/routes/events.routes.ts
+++ b/apps/server/src/routes/events.routes.ts
@@ -1,0 +1,45 @@
+import { Router } from "express";
+import { sessions } from "../core/state";
+import { getEmitter } from "../core/events";
+
+const router = Router();
+
+router.get("/:sessionId/events", (req, res) => {
+  const { sessionId } = req.params;
+
+  // SSE headers
+  res.setHeader("Content-Type", "text/event-stream");
+  res.setHeader("Cache-Control", "no-cache");
+  res.setHeader("Connection", "keep-alive");
+  res.flushHeaders?.();
+
+  const em = getEmitter(sessionId);
+
+  const send = (evt: { seq: number; session: any }) => {
+    res.write(`id: ${evt.seq}\n`);
+    res.write(`event: update\n`);
+    res.write(`data: ${JSON.stringify({ session: evt.session })}\n\n`);
+  };
+
+  // Send snapshot (if session already exists)
+  const snap = sessions.get(sessionId);
+  if (snap) send({ seq: 0, session: snap });
+
+  // Subscribe to updates
+  const onUpdate = (evt: any) => send(evt);
+  em.on("update", onUpdate);
+
+  // Heartbeat to keep proxies happy
+  const hb = setInterval(() => res.write(`: ping\n\n`), 25000);
+
+  const close = () => {
+    clearInterval(hb);
+    em.off("update", onUpdate);
+    res.end();
+  };
+
+  req.on("close", close);
+  req.on("aborted", close);
+});
+
+export default router;

--- a/apps/server/src/routes/index.routes.ts
+++ b/apps/server/src/routes/index.routes.ts
@@ -1,0 +1,8 @@
+import { Router } from "express";
+import callsRouter from "./calls.routes";
+import eventsRouter from "./events.routes";
+
+const api = Router();
+api.use("/calls", callsRouter);
+api.use("/calls", eventsRouter);
+export default api;

--- a/apps/server/src/services/telnyx.client.ts
+++ b/apps/server/src/services/telnyx.client.ts
@@ -2,6 +2,14 @@ import { env } from "../config";
 
 const BASE = "https://api.telnyx.com/v2";
 
+type DialParams = {
+  to: string;
+  from: string;
+  connection_id: string;
+  client_state: string;
+  command_id?: string;
+};
+
 async function tFetch(path: string, init: RequestInit = {}) {
   const headers = {
     "Content-Type": "application/json",
@@ -16,20 +24,15 @@ async function tFetch(path: string, init: RequestInit = {}) {
   return res.json();
 }
 
-/** Marca una llamada (Dial) */
-export async function dial(params: {
-  to: string;
-  from: string;
-  connection_id: string;
-  client_state?: string;
-}) {
+/** Make a call (Dial) */
+export async function dial(params: DialParams) {
   return tFetch("/calls", {
     method: "POST",
     body: JSON.stringify(params),
   });
 }
 
-/** Bridge: une A con B */
+/** Bridge: match A with B */
 export async function bridge(aCallControlId: string, bCallControlId: string) {
   return tFetch(`/calls/${aCallControlId}/actions/bridge`, {
     method: "POST",

--- a/apps/server/src/webhooks/telnyx.webhook.ts
+++ b/apps/server/src/webhooks/telnyx.webhook.ts
@@ -4,6 +4,7 @@ import { sessions } from "../core/state";
 import { env } from "../config";
 import { dial, bridge } from "../services/telnyx.client";
 import { TelnyxWebhook } from "@core/types";
+import { publishSession } from "@core/events";
 
 function decodeClientState(
   b64?: string
@@ -16,67 +17,157 @@ function decodeClientState(
   }
 }
 
+const seenEvents = new Set<string>();
+function isDuplicate(id?: string) {
+  if (!id) return false;
+  if (seenEvents.has(id)) return true;
+  seenEvents.add(id);
+  // keep it bounded
+  if (seenEvents.size > 5000) {
+    // cheap reset; OK for dev
+    seenEvents.clear();
+  }
+  return false;
+}
+
+function log(sessionId: string | null, msg: string, extra?: any) {
+  const prefix = sessionId ? `[WH ${sessionId}]` : `[WH]`;
+  if (extra !== undefined) {
+    console.log(prefix, msg, extra);
+  } else {
+    console.log(prefix, msg);
+  }
+}
+
 export async function telnyxWebhook(req: Request, res: Response) {
   const raw = (req as any).rawBody as Buffer;
+
+  // 0) Verify signature
   if (!verifyTelnyxSignature(raw, req.headers)) {
+    console.warn("[WH] invalid signature");
     return res.status(400).send("invalid signature");
   }
 
   const body = req.body as TelnyxWebhook;
+  const eventId = (body as any)?.data?.id || (body as any)?.id || undefined;
   const { event_type, payload } = body.data;
   const client = decodeClientState(payload.client_state);
+  const sessionId = client?.sessionId ?? null;
+
+  // top-level log for every event
+  log(sessionId, `← ${event_type}`, {
+    eventId,
+    to: payload.to,
+    from: payload.from,
+    call_control_id: payload.call_control_id,
+    leg: client?.leg,
+  });
+
+  // 1) Deduplicate (optional but helpful if ngrok/infra resends)
+  if (isDuplicate(eventId)) {
+    log(sessionId, `duplicate event ignored`, { eventId, event_type });
+    return res.status(200).send("ok");
+  }
 
   if (!client?.sessionId) {
+    log(null, "missing/invalid client_state; ack and drop");
     return res.status(200).send("ok");
   }
 
   const s = sessions.get(client.sessionId);
-  if (!s) return res.status(200).send("ok");
+  if (!s) {
+    log(sessionId, "session not found; ack and drop");
+    return res.status(200).send("ok");
+  }
 
-  // 1) Guardar call_control_id al iniciarse cada leg
+  // 2) call.initiated (store call_control_id and state)
   if (event_type === "call.initiated") {
     if (client.leg === "A") {
       s.a.callControlId = payload.call_control_id;
       s.a.status = "dialing";
       s.status = "a_dialing";
+      log(sessionId, "A leg initiated", {
+        callControlId: s.a.callControlId,
+        to: payload.to,
+      });
     } else if (client.leg === "B") {
       s.b.callControlId = payload.call_control_id;
       s.b.status = "dialing";
       s.status = "b_dialing";
+      log(sessionId, "B leg initiated", {
+        callControlId: s.b.callControlId,
+        to: payload.to,
+      });
     }
+    publishSession(s.sessionId, s);
     return res.status(200).send("ok");
   }
 
-  // 2) Disparar B solo si A fue realmente contestado (candados extra)
+  // 3) A answered → dial B (with extra guards and logs)
   if (event_type === "call.answered" && client.leg === "A") {
     const isRightCall =
-      s.a.callControlId && payload.call_control_id === s.a.callControlId;
-    const numberMatches = payload.to === s.fromPhone; // el A se marcó hacia fromPhone
+      !!s.a.callControlId && payload.call_control_id === s.a.callControlId;
+    const numberMatches = payload.to === s.fromPhone;
+
+    log(sessionId, "A answered", {
+      isRightCall,
+      numberMatches,
+      status: s.status,
+      aCallControlId: s.a.callControlId,
+      webhookCallControlId: payload.call_control_id,
+      expectedTo: s.fromPhone,
+      gotTo: payload.to,
+    });
 
     if (isRightCall && numberMatches && s.status === "a_dialing") {
       s.a.status = "answered";
       s.status = "a_answered";
 
+      // Prepare client_state & command_id for B dial
       const clientStateB = Buffer.from(
         JSON.stringify({ sessionId: s.sessionId, leg: "B" })
       ).toString("base64");
+
+      // Optional idempotency key for Dial (see note below)
+      const commandIdB =
+        (s as any).b?.dialCommandId || `dial:${s.sessionId}:B:1`;
+      (s as any).b = { ...(s as any).b, dialCommandId: commandIdB };
+
+      log(sessionId, "Dialing B", {
+        to: s.toPhone,
+        from: env.TELNYX_NUMBER,
+        command_id: commandIdB,
+      });
 
       await dial({
         to: s.toPhone,
         from: env.TELNYX_NUMBER!,
         connection_id: env.TELNYX_CONNECTION_ID!,
         client_state: clientStateB,
+        command_id: commandIdB, // ← will be ignored by Telnyx if duplicate
       });
+
       s.status = "b_dialing";
     }
+
+    publishSession(s.sessionId, s);
     return res.status(200).send("ok");
   }
 
-  // 3) Cuando B contesta, recién entonces bridge A <-> B
+  // 4) B answered → bridge A <-> B
   if (event_type === "call.answered" && client.leg === "B") {
     const isRightCall =
-      s.b.callControlId && payload.call_control_id === s.b.callControlId;
+      !!s.b.callControlId && payload.call_control_id === s.b.callControlId;
     const numberMatches = payload.to === s.toPhone;
+
+    s.b.status = "answered";
+    log(sessionId, "B answered", {
+      isRightCall,
+      numberMatches,
+      aCallControlId: s.a.callControlId,
+      bCallControlId: s.b.callControlId,
+    });
+    publishSession(s.sessionId, s);
 
     if (
       isRightCall &&
@@ -84,20 +175,43 @@ export async function telnyxWebhook(req: Request, res: Response) {
       s.a.callControlId &&
       s.b.callControlId
     ) {
+      log(sessionId, "Bridging A <-> B", {
+        a: s.a.callControlId,
+        b: s.b.callControlId,
+      });
       await bridge(s.a.callControlId, s.b.callControlId);
       s.a.status = "bridged";
       s.b.status = "bridged";
       s.status = "bridged";
+      publishSession(s.sessionId, s);
+      log(sessionId, "Bridge complete");
     }
+
     return res.status(200).send("ok");
   }
 
+  // 5) call.bridged (confirmation that they are bridged)
+  if (event_type === "call.bridged") {
+    if (client.leg === "A") s.a.status = "bridged";
+    if (client.leg === "B") s.b.status = "bridged";
+    s.status = "bridged";
+    publishSession(s.sessionId, s);
+    log(sessionId, "Bridged (webhook confirm)");
+    return res.status(200).send("ok");
+  }
+
+  // 6) Hangup
   if (event_type === "call.hangup") {
+    const cause = (payload as any)?.hangup_cause;
+    log(sessionId, "Hangup", { cause });
     s.status = "ended";
     s.a.status = s.a.status === "bridged" ? "ended" : s.a.status;
     s.b.status = s.b.status === "bridged" ? "ended" : s.b.status;
+    publishSession(s.sessionId, s);
     return res.status(200).send("ok");
   }
 
+  // 7) Unhandled -> log + ack
+  log(sessionId, `Unhandled event: ${event_type}`);
   return res.status(200).send("ok");
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -7,9 +7,11 @@ export type StartBridgeResp = {
   sessionId: string;
 };
 
-const BASE = import.meta.env.VITE_API_BASE || "http://localhost:3001";
+export const BASE = import.meta.env.VITE_API_BASE || "http://localhost:3001";
 
-export async function startBridge(body: StartBridgeBody): Promise<StartBridgeResp> {
+export async function startBridge(
+  body: StartBridgeBody
+): Promise<StartBridgeResp> {
   const res = await fetch(`${BASE}/api/calls/bridge`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -1,28 +1,82 @@
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
+import { BASE } from "../lib/api";
 import { startBridge } from "../lib/api";
 import { PhonePad } from "../components/PhonePad";
 import { ProviderToggle } from "../components/ProviderToggle";
 import { ModeTabs } from "../components/ModeTabs";
 
 export default function Home() {
-  const [mode, setMode] = useState<"pstn"|"webrtc">("pstn");
-  const [provider, setProvider] = useState<"telnyx"|"sinch"|"infobip">("telnyx");
+  const esRef = useRef<EventSource | null>(null);
+  const [mode, setMode] = useState<"pstn" | "webrtc">("pstn");
+  const [provider, setProvider] = useState<"telnyx" | "sinch" | "infobip">(
+    "telnyx"
+  );
 
   const looksE164 = (v: string) => /^\+\d{7,15}$/.test(v);
+
+  function mapLegStatus(s?: string) {
+    switch (s) {
+      case "dialing":
+        return "calling";
+      case "answered":
+        return "answered";
+      case "bridged":
+        return "in-call";
+      case "ended":
+        return "ended";
+      default:
+        return "idle";
+    }
+  }
 
   const [from, setFrom] = useState("");
   const [to, setTo] = useState("");
 
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string|null>(null);
-  const [sessionId, setSessionId] = useState<string|null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [sessionId, setSessionId] = useState<string | null>(null);
 
   // Local UI states (T3 this will come from SSE)
   const [stateFrom, setStateFrom] = useState("idle");
   const [stateTo, setStateTo] = useState("idle");
 
+  function openSSE(id: string) {
+    esRef.current?.close();
+    const es = new EventSource(`${BASE}/api/calls/${id}/events`);
+    esRef.current = es;
+
+    const handler = (e: MessageEvent) => {
+      try {
+        const { session } = JSON.parse(e.data);
+
+        // Always update A from server state
+        setStateFrom(mapLegStatus(session?.a?.status));
+
+        // Only update B if the server actually reports a status for leg B.
+        // This preserves the local "holding" we set right after clicking Call.
+        setStateTo(prev => {
+          const b = session?.b?.status as string | undefined;
+          return b ? mapLegStatus(b) : prev;
+        });
+
+        if (session?.status === "ended") es.close();
+      } catch {
+        /* ignore */
+      }
+    };
+
+    es.addEventListener("update", handler); // server sends "event: update"
+    es.onmessage = handler; // fallback if default event is used
+    es.onerror = () => {
+      /* optional: show "reconnecting..." */
+    };
+  }
+
+  useEffect(() => () => esRef.current?.close(), []);
+
   async function dial() {
-    if (!from || !to || loading || mode !== "pstn" || provider !== "telnyx") return;
+    if (!from || !to || loading || mode !== "pstn" || provider !== "telnyx")
+      return;
     setError(null);
     setLoading(true);
     setStateFrom("calling");
@@ -30,7 +84,7 @@ export default function Home() {
     try {
       const { sessionId } = await startBridge({ fromPhone: from, toPhone: to });
       setSessionId(sessionId);
-      // In T3: open SSE here and update real states.
+      openSSE(sessionId);
     } catch (e: unknown) {
       if (typeof e === "object" && e !== null && "message" in e) {
         setError((e as { message?: string }).message ?? "Error");
@@ -45,11 +99,11 @@ export default function Home() {
   }
 
   const canDial =
-  looksE164(from) &&
-  looksE164(to) &&
-  !loading &&
-  mode === "pstn" &&
-  provider === "telnyx";
+    looksE164(from) &&
+    looksE164(to) &&
+    !loading &&
+    mode === "pstn" &&
+    provider === "telnyx";
 
   return (
     <div style={styles.page}>
@@ -58,11 +112,25 @@ export default function Home() {
       </div>
 
       <div style={styles.phonesRow}>
-        <PhonePad title="From" status={stateFrom} value={from} onChange={setFrom} disabled={loading} sx={{justifySelf: 'end'}} />
+        <PhonePad
+          title="From"
+          status={stateFrom}
+          value={from}
+          onChange={setFrom}
+          disabled={loading}
+          sx={{ justifySelf: "end" }}
+        />
         <div style={styles.centerCol}>
           <div style={styles.connector}>
-            <div style={{ ...styles.half, opacity: stateFrom !== "idle" ? 1 : 0.3 }} />
-            <div style={{ ...styles.half, opacity: stateTo !== "idle" ? 1 : 0.3 }} />
+            <div
+              style={{
+                ...styles.half,
+                opacity: stateFrom !== "idle" ? 1 : 0.3,
+              }}
+            />
+            <div
+              style={{ ...styles.half, opacity: stateTo !== "idle" ? 1 : 0.3 }}
+            />
           </div>
           <button
             onClick={dial}
@@ -75,27 +143,96 @@ export default function Home() {
           <ProviderToggle value={provider} onChange={setProvider} />
           {sessionId && (
             <div style={styles.sessionBox}>
-              <div><strong>sessionId:</strong> <code>{sessionId}</code></div>
-              <small>In T3 we will show live events (ringing / answered / bridged).</small>
+              <div>
+                <strong>sessionId:</strong> <code>{sessionId}</code>
+              </div>
             </div>
           )}
           {error && <div style={styles.error}>{error}</div>}
         </div>
-        <PhonePad title="To" status={stateTo} value={to} onChange={setTo} disabled={loading} sx={{justifySelf: 'start'}} />
+        <PhonePad
+          title="To"
+          status={stateTo}
+          value={to}
+          onChange={setTo}
+          disabled={loading}
+          sx={{ justifySelf: "start" }}
+        />
       </div>
     </div>
   );
 }
 
 const styles: Record<string, React.CSSProperties> = {
-  page: { minHeight: "100dvh", background:"#0b1220", color:"#e5e7eb", padding: 24, display:"grid", gap: 24 },
-  topbar: { display:"flex", justifyContent:"center", alignItems:"center" },
-  phonesRow: { display:"grid", gridTemplateColumns:"1fr 1fr 1fr", gap: 20, alignItems:"center", justifyItems:"center" },
-  centerCol: { display:"grid", gap: 16, placeItems:"center", justifyContent: 'center' },
-  callBtn: { padding:"12px 18px", background:"#0ea5e9", border:"none", borderRadius:12, color:"#fff", fontWeight:700, cursor:"pointer" },
-  callBtnDisabled: { padding:"12px 18px", background:"#1f2937", border:"none", borderRadius:12, color:"#9ca3af", fontWeight:700, cursor:"not-allowed" },
-  connector: { width: 160, height: 10, display:"grid", gridTemplateColumns:"1fr 1fr", gap: 4, marginBottom: 8 },
-  half: { height: "100%", background:"#22d3ee", borderRadius: 999, transition:"opacity 200ms ease" },
-  sessionBox: { border:"1px solid #1f2937", background:"#0f172a", borderRadius:12, padding:12, width: 360, textAlign:"center" },
-  error: { background:"#3b0d0d", border:"1px solid #7f1d1d", color:"#fecaca", borderRadius:10, padding:"10px 12px", width: 360, textAlign:"center" },
+  page: {
+    minHeight: "100dvh",
+    background: "#0b1220",
+    color: "#e5e7eb",
+    padding: 24,
+    display: "grid",
+    gap: 24,
+  },
+  topbar: { display: "flex", justifyContent: "center", alignItems: "center" },
+  phonesRow: {
+    display: "grid",
+    gridTemplateColumns: "1fr 1fr 1fr",
+    gap: 20,
+    alignItems: "center",
+    justifyItems: "center",
+  },
+  centerCol: {
+    display: "grid",
+    gap: 16,
+    placeItems: "center",
+    justifyContent: "center",
+  },
+  callBtn: {
+    padding: "12px 18px",
+    background: "#0ea5e9",
+    border: "none",
+    borderRadius: 12,
+    color: "#fff",
+    fontWeight: 700,
+    cursor: "pointer",
+  },
+  callBtnDisabled: {
+    padding: "12px 18px",
+    background: "#1f2937",
+    border: "none",
+    borderRadius: 12,
+    color: "#9ca3af",
+    fontWeight: 700,
+    cursor: "not-allowed",
+  },
+  connector: {
+    width: 160,
+    height: 10,
+    display: "grid",
+    gridTemplateColumns: "1fr 1fr",
+    gap: 4,
+    marginBottom: 8,
+  },
+  half: {
+    height: "100%",
+    background: "#22d3ee",
+    borderRadius: 999,
+    transition: "opacity 200ms ease",
+  },
+  sessionBox: {
+    border: "1px solid #1f2937",
+    background: "#0f172a",
+    borderRadius: 12,
+    padding: 12,
+    width: 360,
+    textAlign: "center",
+  },
+  error: {
+    background: "#3b0d0d",
+    border: "1px solid #7f1d1d",
+    color: "#fecaca",
+    borderRadius: 10,
+    padding: "10px 12px",
+    width: 360,
+    textAlign: "center",
+  },
 };


### PR DESCRIPTION
### Summary
Introduce Server-Sent Events (SSE) to stream per-session call updates from the server and reflect them in the UI in near-real time.
Fix raw-body handling for Telnyx webhooks, add structured webhook logging & lightweight dedupe, and confirm call.bridged via webhook.

### What’s included
- SSE endpoint: GET /api/calls/:sessionId/events
    - Sends event: update with the latest session snapshot.
    - Initial snapshot + heartbeat; clean teardown on disconnect.
- Event bus: per-session EventEmitter and publishSession(...).
- Webhook pipeline
    - Raw-body capture before express.json() for Ed25519 verification.
    - Detailed logs for call.initiated, call.answered, call.bridged, call.hangup.
    - Idempotency guard for duplicate webhook events (in-memory eventId set).
    - Dial idempotency: pass command_id on B leg Dial.
    - Handle call.bridged to re-publish “bridged” state (idempotent).
- Web UI
    - Subscribe to named SSE event update (with onmessage fallback).
    - Map leg statuses to UI states; keep To=holding until leg B has a real status.
    - Initial UI on “Call”: From=calling, To=holding; transitions driven by SSE.

closes #3 