### PR TITLE
feat(ui): PhonePad tabs (dial/history) and keyboard nav + key highlight

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Caller system</title>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/web/src/components/PhonePad.tsx
+++ b/apps/web/src/components/PhonePad.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useCallback } from "react";
+import { useEffect, useRef, useCallback, useMemo, useState } from "react";
 
 type Props = {
   title: string;
@@ -7,10 +7,44 @@ type Props = {
   onChange: (v: string) => void;
   disabled?: boolean;
   sx?: React.CSSProperties;
+  historyKey?: string;
 };
 
-const KEYS = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "+", "0", "←"];
-const MAX_E164_DIGITS = 15; // Max digits (not counting the leading '+')
+const KEYS = [
+  "1",
+  "2",
+  "3",
+  "4",
+  "5",
+  "6",
+  "7",
+  "8",
+  "9",
+  "+",
+  "0",
+  "←",
+] as const;
+type KeyLabel = (typeof KEYS)[number];
+
+const MAX_E164_DIGITS = 15;
+
+// helpers de historial (localStorage)
+const LS_PREFIX = "callpad:";
+function readHistory(key?: string): string[] {
+  if (!key) return [];
+  const raw = localStorage.getItem(LS_PREFIX + key);
+  if (!raw) return [];
+  try {
+    const arr = JSON.parse(raw);
+    return Array.isArray(arr) ? arr.filter(Boolean) : [];
+  } catch {
+    return [];
+  }
+}
+function clearHistory(key?: string) {
+  if (!key) return;
+  localStorage.removeItem(LS_PREFIX + key);
+}
 
 /**
  * Compute the next value enforcing E.164 constraints:
@@ -22,11 +56,9 @@ function nextValueE164(curr: string, key: string) {
   if (key === "←") return curr.slice(0, -1);
 
   if (key === "+") {
-    // Allow '+' only if the current value is empty
     return curr.length === 0 ? "+" : curr;
   }
 
-  // Allow digits 0..9 only
   if (!/^\d$/.test(key)) return curr;
 
   const digits = curr.replace(/^\+/, "");
@@ -42,10 +74,30 @@ export function PhonePad({
   onChange,
   disabled,
   sx,
+  historyKey,
 }: Props) {
   const screenRef = useRef<HTMLDivElement>(null);
 
-  // Use useCallback so the effect can safely depend on `press` (no ESLint warning)
+  // Tabs: keypad vs history
+  const [tab, setTab] = useState<"dial" | "history">("dial");
+  const [history, setHistory] = useState<string[]>(readHistory(historyKey));
+
+  // Navigation + highlight
+  const [focusIdx, setFocusIdx] = useState<number>(0);
+  const [activeIdx, setActiveIdx] = useState<number | null>(null);
+
+  const badge = useMemo(() => {
+    const s = String(status || "idle").toLowerCase();
+    if (["calling", "dialing", "a_dialing", "b_dialing"].includes(s))
+      return { label: "Calling", bg: "var(--accent, #0ea5e9)" };
+    if (["answered", "a_answered"].includes(s))
+      return { label: "Answered", bg: "#10b981" };
+    if (["in-call", "bridged"].includes(s))
+      return { label: "In-call", bg: "#22d3ee" };
+    if (["ended"].includes(s)) return { label: "Ended", bg: "#9ca3af" };
+    return { label: "Idle", bg: "#475569" };
+  }, [status]);
+
   const press = useCallback(
     (k: string) => {
       if (disabled) return;
@@ -55,27 +107,89 @@ export function PhonePad({
     [disabled, value, onChange]
   );
 
-  // Physical keyboard support: digits, '+', Backspace
+  // Keyboard + arrows + Enter/Backspace
   useEffect(() => {
     const el = screenRef.current;
     if (!el) return;
     const onKey = (e: KeyboardEvent) => {
       if (disabled) return;
-      if (/^[0-9]$/.test(e.key)) press(e.key);
-      else if (e.key === "+" || (e.shiftKey && e.key === "=")) press("+");
-      else if (e.key === "Backspace") press("←");
+
+      // Only navigate/activate when in dial tab
+      if (tab === "dial") {
+        if (e.key === "Enter") {
+          e.preventDefault();
+          const label = KEYS[focusIdx];
+          press(label);
+          setActiveIdx(focusIdx);
+          setTimeout(() => setActiveIdx(null), 120);
+          return;
+        }
+        if (e.key === "Backspace") {
+          e.preventDefault();
+          press("←");
+          setActiveIdx(KEYS.length - 1);
+          setTimeout(() => setActiveIdx(null), 120);
+          return;
+        }
+        if (/^\d$/.test(e.key)) {
+          press(e.key);
+          const idx = KEYS.indexOf(e.key as KeyLabel);
+          if (idx >= 0) {
+            setActiveIdx(idx);
+            setFocusIdx(idx);
+            setTimeout(() => setActiveIdx(null), 120);
+          }
+          return;
+        }
+        if (e.key === "+" || (e.shiftKey && e.key === "=")) {
+          press("+");
+          const idx = KEYS.indexOf("+");
+          setActiveIdx(idx);
+          setFocusIdx(idx);
+          setTimeout(() => setActiveIdx(null), 120);
+          return;
+        }
+
+        // Arrow navigation
+        const col = focusIdx % 3;
+        const row = Math.floor(focusIdx / 3);
+        if (e.key === "ArrowLeft") {
+          setFocusIdx(Math.max(row * 3 + (col - 1), row * 3));
+          return;
+        }
+        if (e.key === "ArrowRight") {
+          setFocusIdx(Math.min(row * 3 + (col + 1), row * 3 + 2));
+          return;
+        }
+        if (e.key === "ArrowUp") {
+          setFocusIdx(Math.max(focusIdx - 3, 0));
+          return;
+        }
+        if (e.key === "ArrowDown") {
+          setFocusIdx(Math.min(focusIdx + 3, KEYS.length - 1));
+          return;
+        }
+      } else {
+        if (e.key === "Backspace") {
+          e.preventDefault();
+          press("←");
+        }
+      }
     };
     el.addEventListener("keydown", onKey);
     return () => el.removeEventListener("keydown", onKey);
-  }, [disabled, press]);
+  }, [disabled, press, focusIdx, tab]);
+
+  // Record refresh in tab change
+  useEffect(() => {
+    if (tab === "history") setHistory(readHistory(historyKey));
+  }, [tab, historyKey]);
 
   return (
     <div style={{ ...styles.device, ...sx }}>
-      {/* Decorative side buttons (volume / power) */}
       <div style={styles.sideLeft} aria-hidden />
       <div style={styles.sideRight} aria-hidden />
 
-      {/* Screen */}
       <div
         ref={screenRef}
         style={styles.screen}
@@ -83,27 +197,51 @@ export function PhonePad({
         role="group"
         aria-label={`${title} phone`}
       >
-        {/* Notch */}
         <div style={styles.notchWrap}>
           <div style={styles.notch} />
         </div>
 
-        {/* Header: title + status */}
-        <div style={styles.topRow}>
+        <div style={styles.header}>
+          <div style={styles.headerLeft}>
+            <button
+              onClick={() => setTab("dial")}
+              title="Keypad"
+              style={tab === "dial" ? styles.tabActive : styles.tab}
+            >
+              {/* phone icon */}
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
+                <path
+                  d="M22 16.92v3a2 2 0 0 1-2.18 2 19.8 19.8 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6A19.8 19.8 0 0 1 2.08 4.18 2 2 0 0 1 4 2h3a2 2 0 0 1 2 1.72c.12.9.31 1.78.57 2.63a2 2 0 0 1-.45 2.11L8 9a16 16 0 0 0 6 6l.54-1.12a2 2 0 0 1 2.11-.45c.85.26 1.73.45 2.63.57A2 2 0 0 1 22 16.92Z"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                />
+              </svg>
+            </button>
+            <button
+              onClick={() => setTab("history")}
+              title="History"
+              style={tab === "history" ? styles.tabActive : styles.tab}
+            >
+              {/* record icon */}
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
+                <path
+                  d="M3 3v5h5M3.05 13A9 9 0 1 0 8 3.48"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                />
+                <path d="M12 7v5l3 3" stroke="currentColor" strokeWidth="2" />
+              </svg>
+            </button>
+          </div>
+
           <div style={styles.title}>{title}</div>
-          <div
-            style={{
-              ...styles.status,
-              background: status === "idle" ? "#0a1a2a" : "#082a2f",
-              borderColor: "var(--muted)",
-              color: status === "idle" ? "#9ca3af" : "#93c5fd",
-            }}
-          >
-            {status}
+
+          <div style={{ ...styles.statusBadge, background: badge.bg }}>
+            {badge.label}
           </div>
         </div>
 
-        {/* Number display */}
+        {/* Display */}
         <div
           style={{ ...styles.numberBox, opacity: value ? 1 : 0.7 }}
           onClick={() => screenRef.current?.focus()}
@@ -112,22 +250,68 @@ export function PhonePad({
           {value || "—"}
         </div>
 
-        {/* Dialpad */}
-        <div style={styles.pad}>
-          {KEYS.map((k) => (
-            <button
-              key={k}
-              onClick={() => press(k)}
-              disabled={disabled}
-              aria-label={`key ${k}`}
-              style={disabled ? styles.keyDisabled : styles.key}
-            >
-              {k}
-            </button>
-          ))}
-        </div>
+        {/* Content: dialpad or record */}
+        {tab === "dial" ?
+          <div style={styles.pad}>
+            {KEYS.map((k, idx) => {
+              const isActive = activeIdx === idx;
+              const isFocused = focusIdx === idx;
+              const btnStyle = disabled ? styles.keyDisabled : styles.key;
+              return (
+                <button
+                  key={k}
+                  onMouseDown={() => setActiveIdx(idx)}
+                  onMouseUp={() => setActiveIdx(null)}
+                  onMouseLeave={() => setActiveIdx(null)}
+                  onClick={() => {
+                    press(k);
+                    setFocusIdx(idx);
+                    screenRef.current?.focus();
+                  }}
+                  disabled={disabled}
+                  aria-label={`key ${k}`}
+                  style={{
+                    ...btnStyle,
+                    outline: isFocused ? "1px solid var(--accent)" : "none",
+                    transform: isActive ? "translateY(1px)" : "none",
+                  }}
+                >
+                  {k}
+                </button>
+              );
+            })}
+          </div>
+        : <div style={styles.historyBox}>
+            {historyKey ?
+              history.length ?
+                <>
+                  <div style={styles.historyList}>
+                    {history.map(num => (
+                      <button
+                        key={num}
+                        style={styles.historyItem}
+                        onClick={() => onChange(num)}
+                        title="Use this number"
+                      >
+                        {num}
+                      </button>
+                    ))}
+                  </div>
+                  <button
+                    style={styles.clearBtn}
+                    onClick={() => {
+                      clearHistory(historyKey);
+                      setHistory([]);
+                    }}
+                  >
+                    Clear history
+                  </button>
+                </>
+              : <div style={styles.historyEmpty}>No recent calls</div>
+            : <div style={styles.historyEmpty}>History disabled</div>}
+          </div>
+        }
 
-        {/* Home bar */}
         <div style={styles.homeBar} aria-hidden />
       </div>
     </div>
@@ -188,17 +372,41 @@ const styles: Record<string, React.CSSProperties> = {
     background: "#0f172a",
     border: "1px solid #1f2937",
   },
-  topRow: {
-    display: "flex",
+  header: {
+    display: "grid",
+    gridTemplateColumns: "auto 1fr auto",
     alignItems: "center",
-    justifyContent: "space-between",
+    gap: 8,
   },
-  title: { fontWeight: 700, color: "var(--text)" },
-  status: {
+  headerLeft: { display: "flex", gap: 6, alignItems: "center" },
+  tab: {
+    padding: "4px 6px",
+    background: "#0b1220",
+    border: "1px solid #1f2937",
+    borderRadius: 8,
+    color: "#9ca3af",
+    display: "grid",
+    placeItems: "center",
+    cursor: "pointer",
+  },
+  tabActive: {
+    padding: "4px 6px",
+    background: "rgba(34,211,238,0.08)",
+    border: "1px solid var(--accent)",
+    borderRadius: 8,
+    color: "#e5e7eb",
+    display: "grid",
+    placeItems: "center",
+    cursor: "pointer",
+  },
+  title: { fontWeight: 700, color: "var(--text)", textAlign: "center" },
+  statusBadge: {
     fontSize: 12,
     padding: "2px 8px",
     borderRadius: 999,
-    border: "1px solid transparent",
+    color: "#0b1220",
+    fontWeight: 700,
+    justifySelf: "end",
     textTransform: "capitalize",
   },
   numberBox: {
@@ -228,6 +436,7 @@ const styles: Record<string, React.CSSProperties> = {
     height: "clamp(48px, 6.5vh, 64px)",
     cursor: "pointer",
     boxShadow: "inset 0 0 0 1px rgba(255,255,255,0.02)",
+    transition: "transform 80ms ease",
   },
   keyDisabled: {
     padding: 0,
@@ -238,6 +447,37 @@ const styles: Record<string, React.CSSProperties> = {
     fontSize: "clamp(16px, 2vw, 20px)",
     height: "clamp(48px, 6.5vh, 64px)",
     cursor: "not-allowed",
+  },
+  historyBox: {
+    display: "grid",
+    gap: 10,
+    alignContent: "start",
+  },
+  historyList: {
+    display: "grid",
+    gap: 8,
+    maxHeight: 160,
+    overflow: "auto",
+  },
+  historyItem: {
+    textAlign: "left" as const,
+    padding: "8px 10px",
+    borderRadius: 10,
+    border: "1px solid #1f2937",
+    background: "#0b1220",
+    color: "#e5e7eb",
+    cursor: "pointer",
+  },
+  historyEmpty: { opacity: 0.6, padding: "8px 2px" },
+  clearBtn: {
+    justifySelf: "end",
+    fontSize: 12,
+    padding: "6px 10px",
+    borderRadius: 8,
+    border: "1px solid #1f2937",
+    background: "#0b1220",
+    color: "#9ca3af",
+    cursor: "pointer",
   },
   homeBar: {
     height: 5,

--- a/apps/web/src/components/ProviderToggle.tsx
+++ b/apps/web/src/components/ProviderToggle.tsx
@@ -4,15 +4,26 @@ type Props = {
 };
 
 export function ProviderToggle({ value, onChange }: Props) {
-  const Item = ({ id, label, disabled=false }: { id: Props["value"]; label: string; disabled?: boolean }) => (
+  const Item = ({
+    id,
+    label,
+    disabled = false,
+  }: {
+    id: Props["value"];
+    label: string;
+    disabled?: boolean;
+  }) => (
     <button
       onClick={() => !disabled && onChange(id)}
       disabled={disabled}
       style={{
         padding: "8px 12px",
         borderRadius: 10,
-        border: value === id ? "2px solid #0ea5e9" : "1px solid #334155",
-        background: disabled ? "#111827" : (value === id ? "#0b1220" : "#0f172a"),
+        border: value === id ? "2px solid var(--accent)" : "1px solid #334155",
+        background:
+          disabled ? "#111827"
+          : value === id ? "#0b1220"
+          : "#0f172a",
         color: disabled ? "#6b7280" : "#e5e7eb",
         cursor: disabled ? "not-allowed" : "pointer",
         fontWeight: 600,
@@ -24,8 +35,8 @@ export function ProviderToggle({ value, onChange }: Props) {
   return (
     <div style={{ display: "flex", gap: 8 }}>
       <Item id="telnyx" label="Telnyx" />
-      <Item id="sinch" label="Sinch" disabled />
-      <Item id="infobip" label="Infobip" disabled />
+      <Item id="sinch" label="Sinch" />
+      <Item id="infobip" label="Infobip" />
     </div>
   );
 }

--- a/apps/web/src/components/Timer.tsx
+++ b/apps/web/src/components/Timer.tsx
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+
+export function Timer({ running }: { running: boolean }) {
+  const [secs, setSecs] = useState(0);
+
+  useEffect(() => {
+    if (!running) {
+      setSecs(0);
+      return;
+    }
+    const id = setInterval(() => setSecs(s => s + 1), 1000);
+    return () => clearInterval(id);
+  }, [running]);
+
+  const mm = String(Math.floor(secs / 60)).padStart(2, "0");
+  const ss = String(secs % 60).padStart(2, "0");
+  return (
+    <span style={{ fontVariantNumeric: "tabular-nums" }}>
+      {mm}:{ss}
+    </span>
+  );
+}

--- a/apps/web/src/components/WebRTCPanel.tsx
+++ b/apps/web/src/components/WebRTCPanel.tsx
@@ -1,17 +1,22 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { PhonePad } from "../components/PhonePad";
 import { ProviderToggle } from "../components/ProviderToggle";
 import { WebRTCDialer } from "../components/WebRTCDialer";
+import { useProviderTheme } from "../styles/useProviderTheme";
+import { Timer } from "./Timer";
 
 type DialerStatus = "idle" | "calling" | "in-call" | "ended";
+type Provider = "telnyx" | "sinch" | "infobip";
 
 export default function WebRTCPanel() {
-  const [provider, setProvider] = useState<"telnyx" | "sinch" | "infobip">(
-    "telnyx"
-  );
+  const [provider, setProvider] = useState<Provider>("telnyx");
+  useProviderTheme(provider);
+
   const [to, setTo] = useState("");
   const [stateTo, setStateTo] = useState<DialerStatus>("idle");
   const [connected, setConnected] = useState(false);
+
+  const inCall = useMemo(() => stateTo === "in-call", [stateTo]);
 
   return (
     <div style={styles.row}>
@@ -21,16 +26,23 @@ export default function WebRTCPanel() {
         value={to}
         onChange={setTo}
         disabled={false}
+        historyKey="webrtc-to"
         sx={{ justifySelf: "end" }}
       />
+
       <div style={styles.controlsCol}>
-        {/* Dialer renders Connect / Disconnect / Call / Hang up / Mute */}
         <WebRTCDialer
           to={to}
           onStatusRight={setStateTo}
           onConnectedChange={setConnected}
         />
-        {/* Provider selection only before connecting */}
+
+        {inCall && (
+          <div style={styles.timerBox}>
+            <strong>Call time:</strong> <Timer running={inCall} />
+          </div>
+        )}
+
         <div
           style={{
             opacity: connected ? 0.5 : 1,
@@ -57,5 +69,13 @@ const styles: Record<string, React.CSSProperties> = {
     gap: 16,
     placeItems: "center",
     justifyContent: "center",
+  },
+  timerBox: {
+    border: "1px solid #1f2937",
+    background: "#0f172a",
+    borderRadius: 12,
+    padding: 10,
+    width: 200,
+    textAlign: "center",
   },
 };

--- a/apps/web/src/lib/callHistory.ts
+++ b/apps/web/src/lib/callHistory.ts
@@ -1,0 +1,30 @@
+// Tiny call history helper (localStorage-backed).
+// Keeps up to MAX entries per key, newest first, de-duplicated.
+
+const LS_PREFIX = "callpad:";
+const MAX = 20;
+
+function safeParse(json: string | null): string[] {
+  if (!json) return [];
+  try {
+    const arr = JSON.parse(json);
+    return Array.isArray(arr) ? arr.filter(Boolean) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function readHistory(key: string): string[] {
+  return safeParse(localStorage.getItem(LS_PREFIX + key));
+}
+
+export function addHistory(key: string, num: string) {
+  if (!num) return;
+  const current = readHistory(key).filter(n => n !== num);
+  const next = [num, ...current].slice(0, MAX);
+  localStorage.setItem(LS_PREFIX + key, JSON.stringify(next));
+}
+
+export function clearHistory(key: string) {
+  localStorage.removeItem(LS_PREFIX + key);
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,10 +1,11 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import "./index.css";
+import "./styles/theme.css";
+import App from "./App.tsx";
 
-createRoot(document.getElementById('root')!).render(
+createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <App />
-  </StrictMode>,
-)
+  </StrictMode>
+);

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -12,7 +12,9 @@ export default function Home() {
         <ModeTabs value={mode} onChange={setMode} />
       </div>
 
-      {mode === "pstn" ? <PSTNPanel /> : <WebRTCPanel />}
+      {mode === "pstn" ?
+        <PSTNPanel />
+      : <WebRTCPanel />}
     </div>
   );
 }

--- a/apps/web/src/styles/theme.css
+++ b/apps/web/src/styles/theme.css
@@ -1,0 +1,15 @@
+:root {
+  --accent: #0ea5e9;
+}
+
+body[data-provider="telnyx"] {
+  --accent: #00e3aa;
+}
+
+body[data-provider="sinch"] {
+  --accent: #ffbe3c;
+}
+
+body[data-provider="infobip"] {
+  --accent: #fc6423;
+}

--- a/apps/web/src/styles/useProviderTheme.ts
+++ b/apps/web/src/styles/useProviderTheme.ts
@@ -1,0 +1,7 @@
+import { useEffect } from "react";
+
+export function useProviderTheme(provider: "telnyx" | "sinch" | "infobip") {
+  useEffect(() => {
+    document.body.setAttribute("data-provider", provider);
+  }, [provider]);
+}


### PR DESCRIPTION
### Summary
This PR polishes the web UI around the dialer. It ships a redesigned PhonePad (“v2”) with Dial/Recents tabs, full keyboard navigation, consistent status badges, and lightweight error banners. It also introduces provider theming (accent color) for Telnyx/Sinch/Infobip. Server/API behavior is unchanged.

### What’s included

**Web / UI**

- PhonePad v2
    - Header layout: title centered; tabs on the top-left (📞 Dial / 🗒 Recents).
    - Recents list: quick redial by click/tap; stored in-memory (easy to switch to localStorage later if desired).
    - Input rules: strict E.164 (+ plus leading, up to 15 digits).
    - Keyboard support: arrows move a virtual focus across keys; Enter “presses” the focused key; Backspace deletes; digits/+ type directly.
    - Focus & active states: visual highlight for focused key and pressed animation.
    - Bug fix: prevents the “mouse click + Enter” double-entry issue (buttons no longer steal browser focus, and Enter is handled without triggering an implicit click).
    - Status badges: consistent styling for idle, calling, answered, in-call, ended.
    - Error banner: small, non-intrusive inline message.
- Global CSS variable --accent with provider colors via body[data-provider]:
    - Telnyx: #00e3aa
    - Sinch: #ffbe3c
    - Infobip: #fc6423

### What’s not changed
- No server or REST/API changes.
- PSTN and WebRTC call flows remain the same.

Closes #11 